### PR TITLE
Depend on standard-internals over all of standard

### DIFF
--- a/bin/standard5
+++ b/bin/standard5
@@ -1,12 +1,20 @@
 #!/usr/bin/env node
 
 var path = require('path')
-
-var engine = require('standard/node_modules/standard-engine')
-var opts = require('standard/options')
-
-Object.assign(opts.eslintConfig, {
-  configFile: path.join(__dirname, '..', 'eslintConfig.json')
-})
+var pkg = require('../package.json')
+var engine = require('standard-engine')
+var eslint = require('eslint')
+var opts = {
+  version: pkg.version,
+  homepage: pkg.homepage,
+  bugs: pkg.bugs.url,
+  tagline: 'standard for ES5 browsers',
+  cmd: pkg.name,
+  cwd: '',
+  eslint: eslint,
+  eslintConfig: {
+    configFile: path.join(__dirname, '..', 'eslintConfig.json')
+  }
+}
 
 engine.cli(opts)

--- a/package.json
+++ b/package.json
@@ -29,9 +29,13 @@
   "bugs": {
     "url": "https://github.com/KidkArolis/standard5/issues"
   },
-  "homepage": "https://github.com/KidkArolis/standard5#readme",
+  "homepage": "https://github.com/KidkArolis/standard5",
   "dependencies": {
-    "standard": "^7.1.0"
+    "eslint": "^3.4.0",
+    "eslint-config-standard": "^6.0.0",
+    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-standard": "^2.0.0",
+    "standard-engine": "^5.1.0"
   },
   "devDependencies": {
     "kn-release": "^1.0.1"


### PR DESCRIPTION
This is actually what stuff like semistandard does. It'll work with npm@3 now. It's only 1mb less dependencies, but still. It's how you're supposed to do it, apparently.

Not even sure the eslint plugins are required... so could maybe remove those. The standard config repo just recommends them.
